### PR TITLE
Fix typo in v2 template

### DIFF
--- a/zabbix_templates/zbx_ceph_cluster_template.xml
+++ b/zabbix_templates/zbx_ceph_cluster_template.xml
@@ -106,7 +106,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>cpeh.count</key>
+                    <key>ceph.count</key>
                     <delay>30</delay>
                     <history>90</history>
                     <trends>365</trends>


### PR DESCRIPTION
Sorry, I made a little typo when I have converted v1 to v2