### PR TITLE
Fixed misspelling in template names.

### DIFF
--- a/zabbix_templates/zbx_ceph_cluster_template.xml
+++ b/zabbix_templates/zbx_ceph_cluster_template.xml
@@ -9,7 +9,7 @@
     </groups>
     <templates>
         <template>
-            <template>Templace_Ceph_Cluster</template>
+            <template>Template_Ceph_Cluster</template>
             <name>Ceph Cluster</name>
             <groups>
                 <group>
@@ -1213,7 +1213,7 @@
     </templates>
     <triggers>
         <trigger>
-            <expression>{Templace_Ceph_Cluster:ceph.degraded.last(0)}&gt;0</expression>
+            <expression>{Template_Ceph_Cluster:ceph.degraded.last(0)}&gt;0</expression>
             <name>Ceph cluster has degraded PGs</name>
             <url/>
             <status>0</status>
@@ -1223,7 +1223,7 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Templace_Ceph_Cluster:ceph.down.last(0)}&gt;0</expression>
+            <expression>{Template_Ceph_Cluster:ceph.down.last(0)}&gt;0</expression>
             <name>Ceph cluster has down PGs</name>
             <url/>
             <status>0</status>
@@ -1260,7 +1260,7 @@
                     <calc_fnc>1</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.rados_total</key>
                     </item>
                 </graph_item>
@@ -1272,7 +1272,7 @@
                     <calc_fnc>4</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.rados_used</key>
                     </item>
                 </graph_item>
@@ -1304,7 +1304,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.ops</key>
                     </item>
                 </graph_item>
@@ -1316,7 +1316,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.wrbps</key>
                     </item>
                 </graph_item>
@@ -1328,7 +1328,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.rdbps</key>
                     </item>
                 </graph_item>
@@ -1361,7 +1361,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.rados_free</key>
                     </item>
                 </graph_item>
@@ -1373,7 +1373,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.rados_used</key>
                     </item>
                 </graph_item>
@@ -1405,7 +1405,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.degraded_percent</key>
                     </item>
                 </graph_item>
@@ -1437,7 +1437,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.recovering</key>
                     </item>
                 </graph_item>
@@ -1449,7 +1449,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.remapped</key>
                     </item>
                 </graph_item>
@@ -1461,7 +1461,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.peering</key>
                     </item>
                 </graph_item>
@@ -1493,7 +1493,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.osd_up</key>
                     </item>
                 </graph_item>
@@ -1505,7 +1505,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.osd_in</key>
                     </item>
                 </graph_item>
@@ -1537,7 +1537,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.clean</key>
                     </item>
                 </graph_item>
@@ -1549,7 +1549,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.active</key>
                     </item>
                 </graph_item>
@@ -1581,7 +1581,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.degraded</key>
                     </item>
                 </graph_item>
@@ -1593,7 +1593,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.down</key>
                     </item>
                 </graph_item>
@@ -1605,7 +1605,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.incomplete</key>
                     </item>
                 </graph_item>
@@ -1617,7 +1617,7 @@
                     <calc_fnc>2</calc_fnc>
                     <type>0</type>
                     <item>
-                        <host>Templace_Ceph_Cluster</host>
+                        <host>Template_Ceph_Cluster</host>
                         <key>ceph.inconsistent</key>
                     </item>
                 </graph_item>

--- a/zabbix_templates/zbx_ceph_cluster_template_v1_format.xml
+++ b/zabbix_templates/zbx_ceph_cluster_template_v1_format.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export version="1.0" date="11.04.14" time="19.30">
     <hosts>
-        <host name="Templace_Ceph_Cluster">
+        <host name="Template_Ceph_Cluster">
             <proxy_hostid>0</proxy_hostid>
             <useip>1</useip>
             <dns></dns>
@@ -22,7 +22,7 @@
                 <trigger>
                     <description>Ceph cluster has degraded PGs</description>
                     <type>0</type>
-                    <expression>{Templace_Ceph_Cluster:ceph.degraded.last(0)}&gt;0</expression>
+                    <expression>{Template_Ceph_Cluster:ceph.degraded.last(0)}&gt;0</expression>
                     <url/>
                     <status>0</status>
                     <priority>4</priority>
@@ -31,7 +31,7 @@
                 <trigger>
                     <description>Ceph cluster has down PGs</description>
                     <type>0</type>
-                    <expression>{Templace_Ceph_Cluster:ceph.down.last(0)}&gt;0</expression>
+                    <expression>{Template_Ceph_Cluster:ceph.down.last(0)}&gt;0</expression>
                     <url/>
                     <status>0</status>
                     <priority>3</priority>
@@ -1044,7 +1044,7 @@
                     <ymin_item_key></ymin_item_key>
                     <ymax_item_key></ymax_item_key>
                     <graph_elements>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.rados_total">
+                        <graph_element item="Template_Ceph_Cluster:ceph.rados_total">
                             <sortorder>0</sortorder>
                             <drawtype>1</drawtype>
                             <color>00EE00</color>
@@ -1053,7 +1053,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.rados_used">
+                        <graph_element item="Template_Ceph_Cluster:ceph.rados_used">
                             <sortorder>1</sortorder>
                             <drawtype>1</drawtype>
                             <color>EE0000</color>
@@ -1079,7 +1079,7 @@
                     <ymin_item_key></ymin_item_key>
                     <ymax_item_key></ymax_item_key>
                     <graph_elements>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.ops">
+                        <graph_element item="Template_Ceph_Cluster:ceph.ops">
                             <sortorder>1</sortorder>
                             <drawtype>1</drawtype>
                             <color>C80000</color>
@@ -1088,7 +1088,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.wrbps">
+                        <graph_element item="Template_Ceph_Cluster:ceph.wrbps">
                             <sortorder>0</sortorder>
                             <drawtype>0</drawtype>
                             <color>00C800</color>
@@ -1097,7 +1097,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.rdbps">
+                        <graph_element item="Template_Ceph_Cluster:ceph.rdbps">
                             <sortorder>0</sortorder>
                             <drawtype>0</drawtype>
                             <color>0000C8</color>
@@ -1123,7 +1123,7 @@
                     <ymin_item_key></ymin_item_key>
                     <ymax_item_key></ymax_item_key>
                     <graph_elements>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.rados_free">
+                        <graph_element item="Template_Ceph_Cluster:ceph.rados_free">
                             <sortorder>0</sortorder>
                             <drawtype>0</drawtype>
                             <color>00EE00</color>
@@ -1132,7 +1132,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.rados_used">
+                        <graph_element item="Template_Ceph_Cluster:ceph.rados_used">
                             <sortorder>1</sortorder>
                             <drawtype>0</drawtype>
                             <color>EE0000</color>
@@ -1158,7 +1158,7 @@
                     <ymin_item_key></ymin_item_key>
                     <ymax_item_key></ymax_item_key>
                     <graph_elements>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.degraded_percent">
+                        <graph_element item="Template_Ceph_Cluster:ceph.degraded_percent">
                             <sortorder>0</sortorder>
                             <drawtype>5</drawtype>
                             <color>CC0000</color>
@@ -1184,7 +1184,7 @@
                     <ymin_item_key></ymin_item_key>
                     <ymax_item_key></ymax_item_key>
                     <graph_elements>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.recovering">
+                        <graph_element item="Template_Ceph_Cluster:ceph.recovering">
                             <sortorder>0</sortorder>
                             <drawtype>0</drawtype>
                             <color>C80000</color>
@@ -1193,7 +1193,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.remapped">
+                        <graph_element item="Template_Ceph_Cluster:ceph.remapped">
                             <sortorder>1</sortorder>
                             <drawtype>0</drawtype>
                             <color>00C800</color>
@@ -1202,7 +1202,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.peering">
+                        <graph_element item="Template_Ceph_Cluster:ceph.peering">
                             <sortorder>2</sortorder>
                             <drawtype>0</drawtype>
                             <color>0000C8</color>
@@ -1228,7 +1228,7 @@
                     <ymin_item_key></ymin_item_key>
                     <ymax_item_key></ymax_item_key>
                     <graph_elements>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.osd_up">
+                        <graph_element item="Template_Ceph_Cluster:ceph.osd_up">
                             <sortorder>0</sortorder>
                             <drawtype>5</drawtype>
                             <color>00EE00</color>
@@ -1237,7 +1237,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.osd_in">
+                        <graph_element item="Template_Ceph_Cluster:ceph.osd_in">
                             <sortorder>1</sortorder>
                             <drawtype>2</drawtype>
                             <color>CC0000</color>
@@ -1263,7 +1263,7 @@
                     <ymin_item_key></ymin_item_key>
                     <ymax_item_key></ymax_item_key>
                     <graph_elements>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.clean">
+                        <graph_element item="Template_Ceph_Cluster:ceph.clean">
                             <sortorder>1</sortorder>
                             <drawtype>2</drawtype>
                             <color>00EE00</color>
@@ -1272,7 +1272,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.active">
+                        <graph_element item="Template_Ceph_Cluster:ceph.active">
                             <sortorder>0</sortorder>
                             <drawtype>5</drawtype>
                             <color>0000EE</color>
@@ -1298,7 +1298,7 @@
                     <ymin_item_key></ymin_item_key>
                     <ymax_item_key></ymax_item_key>
                     <graph_elements>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.degraded">
+                        <graph_element item="Template_Ceph_Cluster:ceph.degraded">
                             <sortorder>0</sortorder>
                             <drawtype>0</drawtype>
                             <color>00EE00</color>
@@ -1307,7 +1307,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.down">
+                        <graph_element item="Template_Ceph_Cluster:ceph.down">
                             <sortorder>3</sortorder>
                             <drawtype>0</drawtype>
                             <color>EE0000</color>
@@ -1316,7 +1316,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.incomplete">
+                        <graph_element item="Template_Ceph_Cluster:ceph.incomplete">
                             <sortorder>1</sortorder>
                             <drawtype>0</drawtype>
                             <color>0000C8</color>
@@ -1325,7 +1325,7 @@
                             <type>0</type>
                             <periods_cnt>5</periods_cnt>
                         </graph_element>
-                        <graph_element item="Templace_Ceph_Cluster:ceph.inconsistent">
+                        <graph_element item="Template_Ceph_Cluster:ceph.inconsistent">
                             <sortorder>2</sortorder>
                             <drawtype>0</drawtype>
                             <color>C800C8</color>


### PR DESCRIPTION
In the cluster templates, the templates included "Templace" instead of "Template". This was corrected here in both files using sed.